### PR TITLE
SHVC-27-DisableOTAUpdate

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,6 +11,7 @@
       "backgroundColor": "#ffffff"
     },
     "updates": {
+      "enabled": false,
       "fallbackToCacheTimeout": 0
     },
     "assetBundlePatterns": [


### PR DESCRIPTION
this ticket is to disable the OTA update facilitated by expo

Reference: 
https://docs.expo.dev/guides/configuring-ota-updates/