### PR TITLE
SHCV-25  Verifier app says that an SHC is invalid if the @context property is included in the SHC

### DIFF
--- a/src/services/jws/jws-payload.ts
+++ b/src/services/jws/jws-payload.ts
@@ -57,11 +57,6 @@ function checkJwsPayload(jwsPayload: JWSPayload | undefined) {
     }
   }
 
-  if (jwsPayload.vc && Object.keys(jwsPayload.vc).includes('@context')) {
-    console.log("JWS.payload.vc shouldn't have a @context property", ErrorCode.SCHEMA_ERROR)
-    throw ErrorCode.SCHEMA_ERROR
-  }
-
   if (
     !jwsPayload.vc.type ||
     !jwsPayload.vc.type.includes('https://smarthealth.cards#health-card')


### PR DESCRIPTION
This is to forgive to have @context property without throwing the error. 

https://thecommonsproject.atlassian.net/browse/SHCV-25