### PR TITLE
turning off remote config for now for main branch

### DIFF
--- a/resources/public/remote-config/remote_config.json
+++ b/resources/public/remote-config/remote_config.json
@@ -1,4 +1,4 @@
 {
-  "useLegacy": false,
-  "remoteConfigEnabled": true 
+  "useLegacy": true,
+  "remoteConfigEnabled": false
 }


### PR DESCRIPTION
Remote config is still disabled for Verifier Production app. 
This is to revert the settings for now. 