### PR TITLE
SHCV-40   automate ios deploy

### DIFF
--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -1,0 +1,207 @@
+name: IOS Build
+
+on:
+  push:
+    tags:
+      - v-ios*
+jobs:
+  # iosDevRelease:
+  #   name: 'Build and Publish VerifierDev'
+  #   runs-on: macos-11
+  #   env:
+  #     APP_STORE_ISSUER_ID: "${{ secrets.DEV_IOS_APP_STORE_ISSUER_ID }}"
+  #     APP_STORE_KEY: "${{ secrets.DEV_IOS_APP_STORE_KEY }}"
+  #     APP_STORE_KEY_ID: "${{ secrets.DEV_IOS_APP_STORE_KEY_ID }}"
+  #     TEAM_ID: "${{ secrets.DEV_IOS_TEAM_ID }}"
+  #     PROFILE_UUID: "${{ secrets.DEV_IOS_PROFILE_UUID }}"
+  #     CODE_SIGN_CERTIFICATE_BASE64: "${{ secrets.DEV_IOS_CERTIFICATE_BASE64 }}"
+  #     P12_PASSPHRASE: "${{ secrets.DEV_IOS_PASSPHRASE }}"
+  #     PROVISIONING_PROFILE_BASE64: "${{ secrets.DEV_IOS_PROVISIONING_PROFILE_BASE64 }}"
+  #     ENV_NAME: "dev"
+  #     CERTIFICATE_PATH: ${{ github.workspace }}/build_certificate.p12
+  #     PP_PATH: ${{ github.workspace }}/Github_Actions_iOS.mobileprovision
+  #     KEYCHAIN_PATH: ${{ github.workspace }}/app-signing.keychain-db
+  #     API_PRIVATE_KEYS_DIR: "${{ github.workspace }}/ios/private_keys"
+  #     API_KEY_PATH: "${{ github.workspace }}/ios/private_keys/AuthKey_${{ secrets.DEV_IOS_APP_STORE_KEY_ID }}.p8"
+  #     OUTPUT_PATH: "${{github.workspace}}/ios"
+  #     IPA_OUTPUT_NAME: "VerifierDev.ipa"
+
+  # iosProdRelease:
+  #   name: 'Build and Publish VerifierDev'
+  #   runs-on: macos-11
+  #   env:
+  #     APP_STORE_ISSUER_ID: "${{ secrets.DEV_IOS_APP_STORE_ISSUER_ID }}"
+  #     APP_STORE_KEY: "${{ secrets.DEV_IOS_APP_STORE_KEY }}"
+  #     APP_STORE_KEY_ID: "${{ secrets.DEV_IOS_APP_STORE_KEY_ID }}"
+  #     TEAM_ID: "${{ secrets.DEV_IOS_TEAM_ID }}"
+  #     PROFILE_UUID: "${{ secrets.DEV_IOS_PROFILE_UUID }}"
+  #     CODE_SIGN_CERTIFICATE_BASE64: "${{ secrets.DEV_IOS_CERTIFICATE_BASE64 }}"
+  #     P12_PASSPHRASE: "${{ secrets.DEV_IOS_PASSPHRASE }}"
+  #     PROVISIONING_PROFILE_BASE64: "${{ secrets.DEV_IOS_PROVISIONING_PROFILE_BASE64 }}"
+  #     ENV_NAME: "dev"
+  #     CERTIFICATE_PATH: ${{ github.workspace }}/build_certificate.p12
+  #     PP_PATH: ${{ github.workspace }}/Github_Actions_iOS.mobileprovision
+  #     KEYCHAIN_PATH: ${{ github.workspace }}/app-signing.keychain-db
+  #     API_PRIVATE_KEYS_DIR: "${{ github.workspace }}/ios/private_keys"
+  #     API_KEY_PATH: "${{ github.workspace }}/ios/private_keys/AuthKey_${{ secrets.DEV_IOS_APP_STORE_KEY_ID }}.p8"
+  #     OUTPUT_PATH: "${{github.workspace}}/ios"
+  #     IPA_OUTPUT_NAME: "VerifierDev.ipa"
+
+  iosRelease:
+    name: 'Build and Publish VerifierDev'
+    runs-on: macos-11
+    env:
+      DEV_APP_STORE_KEY: "${{ secrets.DEV_IOS_APP_STORE_KEY }}"
+      PROD_APP_STORE_KEY: "${{ secrets.PROD_IOS_APP_STORE_KEY }}"
+      TEAM_ID: "${{ secrets.DEV_IOS_TEAM_ID }}"
+      CERTIFICATE_PATH: ${{ github.workspace }}/build_certificate.p12
+      PP_PATH: ${{ github.workspace }}/Github_Actions_iOS.mobileprovision
+      KEYCHAIN_PATH: ${{ github.workspace }}/app-signing.keychain-db
+      API_PRIVATE_KEYS_DIR: "${{ github.workspace }}/ios/private_keys"
+      OUTPUT_PATH: "${{github.workspace}}/ios"
+
+    steps:
+      - name: Sets env vars for dev
+        run: |
+          echo "APP_STORE_ISSUER_ID=\"${{ secrets.DEV_IOS_APP_STORE_ISSUER_ID }}\"" >> $GITHUB_ENV
+          echo "APP_STORE_KEY<<EOF" >> $GITHUB_ENV
+          echo "$DEV_APP_STORE_KEY" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "APP_STORE_KEY_ID=\"${{ secrets.DEV_IOS_APP_STORE_KEY_ID }}\"" >> $GITHUB_ENV
+          echo "TEAM_ID=${{ secrets.DEV_IOS_TEAM_ID }}" >> $GITHUB_ENV
+          echo "PROFILE_UUID=${{ secrets.DEV_IOS_PROFILE_UUID }}" >> $GITHUB_ENV
+          echo "CODE_SIGN_CERTIFICATE_BASE64<<EOF" >> $GITHUB_ENV
+          echo "${{ secrets.DEV_IOS_CERTIFICATE_BASE64 }}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "P12_PASSPHRASE=${{ secrets.DEV_IOS_PASSPHRASE }}" >> $GITHUB_ENV
+          echo "PROVISIONING_PROFILE_BASE64<<EOF" >> $GITHUB_ENV
+          echo "${{ secrets.DEV_IOS_PROVISIONING_PROFILE_BASE64 }}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "ENV_NAME=dev" >> $GITHUB_ENV
+          echo "IPA_OUTPUT_NAME=VerifierDev.ipa" >> $GITHUB_ENV
+          echo "API_KEY_PATH=${{ github.workspace }}/ios/private_keys/AuthKey_${{ secrets.DEV_IOS_APP_STORE_KEY_ID }}.p8"  >> $GITHUB_ENV
+          echo "XCODE_SCHEME=VerifierDevReleaseBuild"  >> $GITHUB_ENV
+          echo "CODE_SIGN_IDENTITY=${{ secrets.DEV_IOS_CODE_SIGN_IDENTITY }}" >> $GITHUB_ENV
+        if: contains(github.ref, 'release-dev')
+      - name: Sets env vars for dev
+        run: |
+          echo "APP_STORE_ISSUER_ID=\"${{ secrets.PROD_IOS_APP_STORE_ISSUER_ID }}\"" >> $GITHUB_ENV
+          echo "APP_STORE_KEY<<EOF" >> $GITHUB_ENV
+          echo "$PROD_APP_STORE_KEY" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "APP_STORE_KEY_ID=\"${{ secrets.PROD_IOS_APP_STORE_KEY_ID }}\"" >> $GITHUB_ENV
+          echo "TEAM_ID=${{ secrets.PROD_IOS_TEAM_ID }}" >> $GITHUB_ENV
+          echo "PROFILE_UUID=${{ secrets.PROD_IOS_PROFILE_UUID }}" >> $GITHUB_ENV
+          echo "CODE_SIGN_CERTIFICATE_BASE64<<EOF" >> $GITHUB_ENV
+          echo "${{ secrets.PROD_IOS_CERTIFICATE_BASE64 }}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "P12_PASSPHRASE=${{ secrets.PROD_IOS_PASSPHRASE }}" >> $GITHUB_ENV
+          echo "PROVISIONING_PROFILE_BASE64<<EOF" >> $GITHUB_ENV
+          echo "${{ secrets.PROD_IOS_PROVISIONING_PROFILE_BASE64 }}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "ENV_NAME=prod">> $GITHUB_ENV
+          echo "IPA_OUTPUT_NAME=Verifier.ipa" >> $GITHUB_ENV
+          echo "API_KEY_PATH=${{ github.workspace }}/ios/private_keys/AuthKey_${{ secrets.PROD_IOS_APP_STORE_KEY_ID }}.p8"  >> $GITHUB_ENV
+          echo "XCODE_SCHEME=ReleaseBuild"  >> $GITHUB_ENV
+          echo "CODE_SIGN_IDENTITY=${{ secrets.PROD_IOS_CODE_SIGN_IDENTITY }}" >> $GITHUB_ENV
+        if: contains(github.ref, 'release-prod') 
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+      - name: Check out Git repository
+        uses: actions/checkout@v2  
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 13.2.1
+      - name: 'Create env file'
+        run: |
+          echo "${{ secrets.DEV_BUILD_CONFIG }}" >> .env.staging
+        if: contains(github.ref, 'release-dev')
+      - name: 'Create env file'
+        run: |
+          echo "${{ secrets.PROD_BUILD_CONFIG }}" >> .env.production
+        if: contains(github.ref, 'release-prod') 
+
+      - name: 'Create api key file'
+        run: |
+          mkdir ${API_PRIVATE_KEYS_DIR}
+          echo "API_KEY_PATH=${API_KEY_PATH}"
+          echo "${APP_STORE_KEY}" >> ${API_KEY_PATH}
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - run: npm install
+
+      - name: Restore buildcache
+        uses: mikehardy/buildcache-action@v1
+        continue-on-error: true
+
+      - name: Setup Ruby (bundle)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+      - name: Setup Build
+        run: |
+          gem install xcodeproj
+          ruby ./tools/deploy/ios/ios_deploy.rb -e ${ENV_NAME}
+
+
+      - name: Install the Apple certificate and provisioning profile
+        run: |
+          # import certificate and provisioning profile from secrets
+          echo -n "$CODE_SIGN_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
+          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode --output $PP_PATH
+          # create temporary keychain
+          security create-keychain -p keychainPassword $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p keychainPassword $KEYCHAIN_PATH
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P $P12_PASSPHRASE -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -k keychainPassword $KEYCHAIN_PATH
+          # apply provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+      - name: Bundle Install
+        working-directory: ./ios
+        run: |
+          bundle config path vendor/bundle
+          bundle check || bundle install
+
+      - name: Restore Pods cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ios/Pods
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Install Pods
+        run: cd ios &&  pod install && cd ..
+#        run: cd ios && pod install --repo-update && cd ..
+      - name: Run Fastlane
+        working-directory: ./ios
+        run: |
+          bundle exec fastlane release env:$ENV_NAME
+      # - name: Build 
+      #   working-directory: ./ios
+      #   run: |
+      #     xcodebuild -workspace "Verifier.xcworkspace" archive -scheme VerifierDevReleaseBuild -sdk iphoneos -archivePath ./VerifierDev.xcarchive
+      - name: config setting
+        run: |
+          echo "OUTPUT_PATH=${OUTPUT_PATH}"
+          echo "OUTPUT_NAME=${IPA_OUTPUT_NAME}"
+      - name: Upload to TestFlight
+        working-directory: ./ios
+        run: |
+          echo "uploading ${OUTPUT_PATH}/${IPA_OUTPUT_NAME}"
+          xcrun altool --upload-app -f ${OUTPUT_PATH}/${IPA_OUTPUT_NAME} -t ios --apiKey ${APP_STORE_KEY_ID} --apiIssuer ${APP_STORE_ISSUER_ID}
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ buck-out/
 
 
 #env
+.env
 .env.development
 .env.production
 .env.staging

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'xcodeproj', '~> 0.28.2'

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '11.0'
+platform :ios, '11'
 
 target 'Verifier' do
   permissions_path = '../node_modules/react-native-permissions/ios'
@@ -15,6 +15,7 @@ target 'Verifier' do
     # to enable hermes on iOS, change `false` to `true` and then install pods
     :hermes_enabled => false
   )
+  pod 'YogaKit', '~> 1.7'
 
   pod 'react-native-camera', :path => '../node_modules/react-native-camera'
 
@@ -41,6 +42,15 @@ target 'Verifier' do
 
   post_install do |installer|
     react_native_post_install(installer)
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    #config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+    #__apply_Xcode_12_5_M1_post_install_workaround(installer)
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+      end
+    end
+    `sed -i -e  $'s/__IPHONE_10_0/__IPHONE_14_0/' Pods/RCT-Folly/folly/portability/Time.h`
   end
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -74,7 +74,7 @@ PODS:
   - glog (0.3.5)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.180)
-  - Permission-Camera (3.1.0):
+  - Permission-Camera (3.3.1):
     - RNPermissions
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -288,7 +288,7 @@ PODS:
     - React-Core
   - react-native-netinfo (7.1.12):
     - React-Core
-  - react-native-safe-area-context (3.3.2):
+  - react-native-safe-area-context (3.4.1):
     - React-Core
   - React-perflogger (0.66.2)
   - React-RCTActionSheet (0.66.2):
@@ -355,21 +355,21 @@ PODS:
     - React-jsi (= 0.66.2)
     - React-logger (= 0.66.2)
     - React-perflogger (= 0.66.2)
-  - RNCAsyncStorage (1.16.1):
+  - RNCAsyncStorage (1.17.5):
     - React-Core
-  - RNDeviceInfo (8.4.5):
+  - RNDeviceInfo (8.7.1):
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNLocalize (2.1.7):
+  - RNLocalize (2.2.1):
     - React-Core
-  - RNPermissions (3.1.0):
+  - RNPermissions (3.3.1):
     - React-Core
-  - RNScreens (3.9.0):
+  - RNScreens (3.13.1):
     - React-Core
     - React-RCTImage
-  - RNSVG (12.1.1):
-    - React
+  - RNSVG (12.3.0):
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -440,6 +440,7 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
+  - YogaKit (~> 1.7)
 
 SPEC REPOS:
   trunk:
@@ -563,7 +564,7 @@ SPEC CHECKSUMS:
   glog: 5337263514dd6f09803962437687240c5dc39aa4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  Permission-Camera: 1f383e3f9a38ba393c63ba9b09a4726f94eda769
+  Permission-Camera: 273b78e214eae8d734d1c497b67aa0030838c006
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 5e9e85f48da8dd447f5834ce14c6799ea8c7f41a
   RCTTypeSafety: aba333d04d88d1f954e93666a08d7ae57a87ab30
@@ -579,7 +580,7 @@ SPEC CHECKSUMS:
   react-native-camera: 210a872c84d3aa0982a9223047ef9e743ed694fa
   react-native-config: 6502b1879f97ed5ac570a029961fc35ea606cd14
   react-native-netinfo: 4bb79fd86e731f85db7d8d132216fa4e9646811c
-  react-native-safe-area-context: 5cf05f49df9d17261e40e518481f2e334c6cd4b5
+  react-native-safe-area-context: 5b8a418400eb3d8364aa87300e865c0262cc17b9
   React-perflogger: 5ab487cacfe6ec19bfe3d3f8072bf71eb07d63da
   React-RCTActionSheet: 03f25695e095fb5aa003828620943c74cc281fec
   React-RCTAnimation: eaf82da39f0c36fb0ef2a28df797c5f73a2a98ea
@@ -592,16 +593,16 @@ SPEC CHECKSUMS:
   React-RCTVibration: 3e815c3d2dd2e0e931b68595b5b92d23ba38b3fb
   React-runtimeexecutor: 393e26602c1b248683372051e34db63e359e3b01
   ReactCommon: c0263c1a41509aeb94be3214fa7bc3b71eae5ef6
-  RNCAsyncStorage: c0754b486fec6e532d358bfd7337cb45c8d2c897
-  RNDeviceInfo: 3b3bbe00f478907223daa580b6882f0bae162f72
+  RNCAsyncStorage: e405f7684be5a2066f5418bb1a4729129ae4feb3
+  RNDeviceInfo: af47a7d1a09d64c8cbb8b0c883db9bca422a9813
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNLocalize: b8980509fc4db6895953aa95b90c8d81cb984603
-  RNPermissions: b3588a19e12bff03fe21bc46911fd32343666dc0
-  RNScreens: 4d79118be80f79fa1f4aa131909a1d6e86280af3
-  RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
+  RNLocalize: 414c99a0f6625a58dfee7f5780678d98c4ffabc2
+  RNPermissions: 7ad8d93b004e6bc85c89e27a102afcde90e07efa
+  RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
+  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Yoga: 9a08effa851c1d8cc1647691895540bc168ea65f
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 313649a5f1fc2193014cf59a63417d5d9b1cc402
+PODFILE CHECKSUM: cafe9f3265f087b936940d23e3b57a57665de484
 
 COCOAPODS: 1.11.2

--- a/ios/Verifier.xcodeproj/xcshareddata/xcschemes/ReleaseBuild.xcscheme
+++ b/ios/Verifier.xcodeproj/xcshareddata/xcschemes/ReleaseBuild.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Env Script"
-               scriptText = "cp &quot;${PROJECT_DIR}/../.env.development&quot; &quot;${PROJECT_DIR}/../.env&quot;  # replace .env.staging for your file&#10;">
+               scriptText = "echo &quot;copying $PROJECT_DIR/../.env.production to $PROJECT_DIR/../.env&quot;&#10;cp &quot;$PROJECT_DIR/../.env.production&quot; &quot;$PROJECT_DIR/.env&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -59,7 +59,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/ios/Verifier.xcodeproj/xcshareddata/xcschemes/Verifier-Test.xcscheme
+++ b/ios/Verifier.xcodeproj/xcshareddata/xcschemes/Verifier-Test.xcscheme
@@ -9,8 +9,8 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Run Env Script"
-               scriptText = "cp &quot;${PROJECT_DIR}/../.env.development&quot; &quot;${PROJECT_DIR}/../.env&quot;  # replace .env.staging for your file&#10;">
+               title = "Run Script"
+               scriptText = "cp &quot;${PROJECT_DIR}/../.env.qa&quot; &quot;${PROJECT_DIR}/../.env&quot;  # replace .env.staging for your file&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/Verifier.xcodeproj/xcshareddata/xcschemes/VerifierDevReleaseBuild.xcscheme
+++ b/ios/Verifier.xcodeproj/xcshareddata/xcschemes/VerifierDevReleaseBuild.xcscheme
@@ -9,8 +9,8 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Run Env Script"
-               scriptText = "cp &quot;${PROJECT_DIR}/../.env.development&quot; &quot;${PROJECT_DIR}/../.env&quot;  # replace .env.staging for your file&#10;">
+               title = "Run Copy Env Script"
+               scriptText = "echo &quot;copying $PROJECT_DIR/../.env.staging to $PROJECT_DIR/../.env&quot;&#10;cp &quot;$PROJECT_DIR/../.env.staging&quot; &quot;$PROJECT_DIR/.env&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -59,7 +59,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,65 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:ios)
+
+platform :ios do
+
+  before_all do |lane|
+    app_store_connect_api_key(
+      key_id: ENV['APP_STORE_KEY_ID'],
+      issuer_id: ENV['APP_STORE_ISSUER_ID'],
+      key_filepath: ENV['API_KEY_PATH'],
+      in_house: true, 
+      duration: 1200,
+    )
+    update_code_signing_settings(
+        path: "Verifier.xcodeproj",
+        use_automatic_signing: false,
+        team_id: ENV['TEAM_ID'],
+        profile_uuid: ENV['PROFILE_UUID'],
+        code_sign_identity: ENV['CODE_SIGN_IDENTITY']
+    )
+  end
+
+  lane :release do |options|
+
+    unlock_keychain(
+      path: ENV['KEYCHAIN_PATH'],
+      password: "keychainPassword",
+      set_default: true
+    )
+
+    build_app(
+      scheme: ENV['XCODE_SCHEME'],
+      output_directory: ENV['OUTPUT_PATH'],
+      output_name: ENV['IPA_OUTPUT_NAME'],
+      silent: false,
+      export_options: {
+        method: "app-store",
+        compileBitcode: false
+      }
+    )
+    app_store_connect_api_key(
+      key_id: ENV['APP_STORE_KEY_ID'],
+      issuer_id: ENV['APP_STORE_ISSUER_ID'],
+      key_filepath: ENV['API_KEY_PATH'],
+      duration: 1200,
+    )
+    # upload_to_testflight
+  end
+
+
+end

--- a/tools/deploy/ios/ios_deploy.rb
+++ b/tools/deploy/ios/ios_deploy.rb
@@ -1,0 +1,86 @@
+require 'xcodeproj'
+require 'pathname'
+require "json"
+require "optparse"
+
+env = "dev"
+op = OptionParser.new do |op|
+  op.banner = 'Usage: ios_deploy [options]'
+  op.separator('Options:')
+  op.on('-e', '--env=ENV') do |_env|
+    puts("arg = #{_env}")
+    if ['prod','dev'].include?( _env )
+        env = _env
+    end
+  end
+  op.on '-h', 'Show this message.' do
+    puts(op)
+    exit
+  end
+end
+
+args = op.parse(ARGV)
+
+unless defined?( PROJECT_ROOT  )
+    PROJECT_ROOT = "#{Pathname.new(__FILE__).realpath.dirname.dirname.dirname.dirname}"
+end
+
+
+unless defined?( IOS_PROJECT_ROOT  )
+    IOS_PROJECT_ROOT = "#{Pathname.new(__FILE__).realpath.dirname.dirname.dirname.dirname}/ios"
+end
+
+
+puts "ios_project_path = #{IOS_PROJECT_ROOT}"
+
+module AppGeneration
+    PATH = "#{IOS_PROJECT_ROOT}"
+    XCODE_PROJ_PATH = "#{PATH}/Verifier.xcodeproj"
+    PROJECT = Xcodeproj::Project.open XCODE_PROJ_PATH
+
+    def install_key_chain
+      home = ENV["HOME"]
+      exec "mkdir -p #{home}/Library/MobileDevice/Provisioning\\ Profiles" if !File.directory?(File.expand_path "#{home}/Library/MobileDevice/Provisioning Profiles")
+      exec "cp #{IOSClient::AppGeneration::APP_PATH}/#{seed_source}.mobileprovision #{home}/Library/MobileDevice/Provisioning\\ Profiles/build-#{build_id}.mobileprovision"
+      exec "rm -f #{IOSClient::AppGeneration::APP_PATH}/*.mobileprovision"
+    end
+
+end
+
+module BuildConfig
+    CONFIG = JSON.parse(File.open("#{PROJECT_ROOT}/buildconfig.json", 'rb').read)
+
+    def version
+        return CONFIG["versionName"]
+    end
+
+    def bundle_id( env )
+        return "#{CONFIG["packageName"]}#{env=="dev" ? ".dev" : ""}"
+    end
+end
+
+
+
+
+include BuildConfig
+
+def update_bundle( bundle_name , version, market_version )
+    AppGeneration::PROJECT.list_by_class( Xcodeproj::Project::XCBuildConfiguration ).each do |config|
+      build_settings = config.build_settings
+      if( build_settings["INFOPLIST_FILE"] == "Verifier/Info.plist")
+          puts("BundleId: #{build_settings["PRODUCT_BUNDLE_IDENTIFIER"]} to #{bundle_name}}")
+          puts("Version: #{build_settings["CURRENT_PROJECT_VERSION"]} to #{version}}")
+          puts("MarketingVersion: #{build_settings["MARKETING_VERSION"]} to #{market_version}}")
+          build_settings["PRODUCT_BUNDLE_IDENTIFIER"] = bundle_name
+          build_settings["CURRENT_PROJECT_VERSION"] = version
+          build_settings["MARKETING_VERSION"] = market_version
+      end
+    end
+    AppGeneration::PROJECT.save()
+end
+
+
+
+puts("Envrionemnt : #{env}") 
+
+update_bundle( bundle_id( env ), version(), version() )


### PR DESCRIPTION
This ticket is to add ios build automation. 
There is no app specific changes, but the fact that we were able to start VerifierDev IOS
means it is working for Development Environment. 
I'll wait to trigger production build till the next release. 