### PR TITLE
TCPE-1589   Verifier Invalid metadata shows unsupported.

### DIFF
--- a/libs/shc-verifier-plugin/src/services/jws/jws-compact.ts
+++ b/libs/shc-verifier-plugin/src/services/jws/jws-compact.ts
@@ -61,8 +61,7 @@ export async function validate ( jws: string ): Promise<any> {
       console.log('ERROR at jwsPayload.validate!')
     }
   }catch (err) {
-    console.log('ERROR at jwsPayload.validate!')
-    //#TODO throw error? 
+    throw err;
   }
   // try to parse JSON even if it failed validation above
   // if we did not get a payload back, it failed to be parsed and we cannot extract the key url


### PR DESCRIPTION
This QR Code should go to Not Verified, not not recognized page. 

<img width="576" alt="Screenshot 2023-04-14 at 11 33 01 AM" src="https://user-images.githubusercontent.com/90639249/232089127-cfdf68fa-58c0-4c2c-a958-a739028a7e07.png">

This related to this mobot test.
https://app.teammobot.com/reports/d30971de-d29f-4f20-993d-651dea0224ce
